### PR TITLE
Support one error use case

### DIFF
--- a/errgroup.go
+++ b/errgroup.go
@@ -17,7 +17,7 @@ func (m MultiError) Error() string {
 		panic("MultiError with no errors")
 	}
 	if l == 1 {
-		panic("MultiError with only 1 error")
+		return m[0].Error()
 	}
 	var b bytes.Buffer
 	b.WriteString("multiple errors: ")


### PR DESCRIPTION
In this way MultiError could be directly used like a real error (not through Group).
